### PR TITLE
Use as a Python library

### DIFF
--- a/assembly_uploader/webin_utils.py
+++ b/assembly_uploader/webin_utils.py
@@ -1,0 +1,18 @@
+import os
+
+ENA_WEBIN = "ENA_WEBIN"
+ENA_WEBIN_PASSWORD = "ENA_WEBIN_PASSWORD"
+
+
+def ensure_webin_credentials_exist():
+    if ENA_WEBIN not in os.environ:
+        raise Exception(f"The variable {ENA_WEBIN} is missing from the env.")
+    if ENA_WEBIN_PASSWORD not in os.environ:
+        raise Exception(f"The variable {ENA_WEBIN_PASSWORD} is missing from the env")
+
+
+def get_webin_credentials():
+    ensure_webin_credentials_exist()
+    webin = os.environ.get(ENA_WEBIN)
+    password = os.environ.get(ENA_WEBIN_PASSWORD)
+    return webin, password

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest==8.2.2",
     "pytest-md==0.2.0",
     "pytest-workflow==2.1.0",
+    "pytest-responses==0.5.1"
 ]
 
 [tool.isort]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 [pytest]
 testpaths = tests
 required_plugins = pytest-workflow
+addopts = --git-aware

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def study_submission_xml_dir():
+    return Path(__file__).resolve().parent / Path("fixtures/SRP272267_upload")
+
+
+@pytest.fixture(scope="module")
+def study_reg_xml(study_submission_xml_dir):
+    return study_submission_xml_dir / Path("SRP272267_reg.xml")
+
+
+@pytest.fixture(scope="module")
+def study_reg_xml_content(study_reg_xml):
+    with study_reg_xml.open() as f:
+        return f.readlines()
+
+
+@pytest.fixture(scope="module")
+def study_submission_xml(study_submission_xml_dir):
+    return study_submission_xml_dir / Path("SRP272267_submission.xml")
+
+
+@pytest.fixture(scope="module")
+def study_submission_xml_content(study_submission_xml):
+    with study_submission_xml.open() as f:
+        return f.readlines()
+
+
+@pytest.fixture(scope="module")
+def assemblies_metadata():
+    return Path(__file__).resolve().parent / Path("fixtures/test_metadata")
+
+
+@pytest.fixture(scope="module")
+def run_manifest(study_submission_xml_dir):
+    return study_submission_xml_dir / Path("SRR12240187.manifest")
+
+
+@pytest.fixture(scope="module")
+def run_manifest_content(run_manifest):
+    with run_manifest.open() as f:
+        return f.readlines()

--- a/tests/fixtures/SRP272267_upload/SRP272267_reg.xml
+++ b/tests/fixtures/SRP272267_upload/SRP272267_reg.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <PROJECT_SET>
 	<PROJECT alias="PRJNA646656_assembly" center_name="EMG">
-		<TITLE>metagenome assembly of PRJNA646656 data set (Metagenomic data reveal diverse fungal and algal communities associated with the lichen symbiosis).</TITLE>
-		<DESCRIPTION>The Third Party Annotation (TPA) assembly was derived from the primary data set PRJNA646656.</DESCRIPTION>
+		<TITLE>Metagenome assembly of PRJNA646656 data set (Metagenomic data reveal diverse fungal and algal communities associated with the lichen symbiosis)</TITLE>
+		<DESCRIPTION>The Third Party Annotation (TPA) assembly was derived from the primary data set PRJNA646656</DESCRIPTION>
 		<SUBMISSION_PROJECT>
 			<SEQUENCING_PROJECT/>
 		</SUBMISSION_PROJECT>

--- a/tests/unit/test_assembly_manifest.py
+++ b/tests/unit/test_assembly_manifest.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import responses
+
+from assembly_uploader.assembly_manifest import AssemblyManifestGenerator
+
+
+def test_assembly_manifest(assemblies_metadata, tmp_path, run_manifest_content):
+    responses.add(
+        responses.POST,
+        "https://www.ebi.ac.uk/ena/portal/api/v2.0/search",
+        json=[
+            {
+                "run_accession": "SRR12240187",
+                "sample_accession": "SAMN15548970",
+                "instrument_model": "Illumina HiSeq 2500",
+                "instrument_platform": "ILLUMINA",
+            }
+        ],
+    )
+    assembly_manifest_gen = AssemblyManifestGenerator(
+        study="SRP272267",
+        assembly_study="PRJ1",
+        assemblies_csv=assemblies_metadata,
+        output_dir=tmp_path,
+    )
+    assembly_manifest_gen.write_manifests()
+
+    manifest_file = tmp_path / Path("SRP272267_upload/SRR12240187.manifest")
+    assert manifest_file.exists()
+
+    with manifest_file.open() as f:
+        assert f.readlines() == run_manifest_content

--- a/tests/unit/test_study_xmls.py
+++ b/tests/unit/test_study_xmls.py
@@ -1,0 +1,47 @@
+import responses
+
+from assembly_uploader import study_xmls
+
+
+def test_study_xmls(tmp_path, study_reg_xml_content, study_submission_xml_content):
+    ena_api = responses.add(
+        responses.POST,
+        "https://www.ebi.ac.uk/ena/portal/api/v2.0/search",
+        json=[
+            {
+                "study_accession": "PRJNA646656",
+                "study_title": "Metagenomic data reveal diverse fungal and algal communities associated with the lichen symbiosis",
+                "study_description": "short, metagnomic reads from lichen thalli",
+                "first_public": "2020-07-18",
+            }
+        ],
+    )
+    study_reg = study_xmls.StudyXMLGenerator(
+        study="SRP272267",
+        center_name="EMG",
+        library=study_xmls.METAGENOME,
+        tpa=True,
+        output_dir=tmp_path,
+    )
+    assert ena_api.call_count == 1
+
+    study_reg.write_study_xml()
+    assert (
+        study_reg._title
+        == "Metagenome assembly of PRJNA646656 data set (Metagenomic data reveal diverse fungal and algal communities associated with the lichen symbiosis)"
+    )
+
+    assert study_reg.study_xml_path.is_relative_to(tmp_path)
+    assert study_reg.study_xml_path.is_file()
+
+    with study_reg.study_xml_path.open() as f:
+        content = f.readlines()
+    assert content == study_reg_xml_content
+
+    study_reg.write_submission_xml()
+    assert study_reg.submission_xml_path.is_relative_to(tmp_path)
+    assert study_reg.submission_xml_path.is_file()
+
+    with study_reg.submission_xml_path.open() as f:
+        content = f.readlines()
+    assert content == study_submission_xml_content

--- a/tests/unit/test_study_xmls.yml
+++ b/tests/unit/test_study_xmls.yml
@@ -6,4 +6,4 @@
     - path: "SRP272267_upload/SRP272267_submission.xml"
       md5sum: bdae52720209d2e70e2911c650a64901
     - path: "SRP272267_upload/SRP272267_reg.xml"
-      md5sum: d2c815fd6ad33847465e55ca5945f0ba
+      md5sum: 1b818a33b786fc9491759f03814b08bf

--- a/tests/unit/test_submit_study.py
+++ b/tests/unit/test_submit_study.py
@@ -10,7 +10,7 @@ from assembly_uploader.webin_utils import (
 
 
 def test_submit_study(study_submission_xml_dir, monkeypatch):
-    ena_dropbopx = responses.add(
+    ena_dropbox = responses.add(
         responses.POST,
         "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit",
         body="""
@@ -31,5 +31,5 @@ def test_submit_study(study_submission_xml_dir, monkeypatch):
     new_study = submit_study(
         "SRP272267", is_test=True, directory=study_submission_xml_dir
     )
-    assert ena_dropbopx.call_count == 1
+    assert ena_dropbox.call_count == 1
     assert new_study == "PRJEA1"

--- a/tests/unit/test_submit_study.py
+++ b/tests/unit/test_submit_study.py
@@ -1,0 +1,35 @@
+import pytest
+import responses
+
+from assembly_uploader.submit_study import submit_study
+from assembly_uploader.webin_utils import (
+    ENA_WEBIN,
+    ENA_WEBIN_PASSWORD,
+    ensure_webin_credentials_exist,
+)
+
+
+def test_submit_study(study_submission_xml_dir, monkeypatch):
+    ena_dropbopx = responses.add(
+        responses.POST,
+        "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit",
+        body="""
+        This is a long receipt from the dropbox.
+        success="true"
+        Your new study has accession="PRJEA1"
+        """,
+    )
+
+    with pytest.raises(Exception):
+        ensure_webin_credentials_exist()
+
+    monkeypatch.setenv(ENA_WEBIN, "fake-webin-999")
+    monkeypatch.setenv(ENA_WEBIN_PASSWORD, "fakewebinpw")
+
+    ensure_webin_credentials_exist()
+
+    new_study = submit_study(
+        "SRP272267", is_test=True, directory=study_submission_xml_dir
+    )
+    assert ena_dropbopx.call_count == 1
+    assert new_study == "PRJEA1"


### PR DESCRIPTION
This PR:
- refactors the code a bit so that steps 1-3 can be done from a Python script, i.e. use `assembly_uploader` as a Python library
- adds a test suite for the python library usage
- tweaks the assembly study title/abstract generation (just formatting issues)
- clarifies a few other points in the README


In short it makes this possible:
```python

from assembly_uploader.study_xmls import StudyXMLGenerator, METAGENOME
from assembly_uploader.submit_study import submit_study
from assembly_uploader.assembly_manifest import AssemblyManifestGenerator

StudyXMLGenerator(
    study="SRP272267",
    center_name="EMG",
    library=METAGENOME,
    tpa=True,
    output_dir=Path("my-study"),
).write()

new_study_accession = submit_study("SRP272267", is_test=True, directory=Path("my-study"))

AssemblyManifestGenerator(
    study="SRP272267",
    assembly_study=new_study_accession,
    assemblies_csv=Path("/path/to/my/assemblies.csv"),
    output_dir=Path("my-study"),
).write()
```