### PR TITLE
Release private studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ ena-webin-cli \
   -submit
 ```
 
+#### Optional step 5: publicly releasing a private study
+```bash
+release_study
+  --study STUDY         study ID (e.g. of the assembly study)
+  --test                run test submission only
+```
+
 More information on ENA's webin-cli can be found [in the ENA docs](<https://ena-docs.readthedocs.io/en/latest/submit/general-guide/webin-cli.html>).
 
 ### From a Python script
@@ -123,6 +130,12 @@ AssemblyManifestGenerator(
 
 The ENA submission requires `webin-cli`, so follow [Step 4](#step-4-upload-assemblies) above.
 (You could still call this from Python, e.g. with `subprocess.Popen`.)
+
+Finally, you can also publicly release a private/embargoed/held study:
+```python
+from assembly_uploader.release_study import release_study
+release_study("SRP272267")
+```
 
 ## Development setup
 Prerequisites: a functioning conda or pixi installation.

--- a/assembly_uploader/release_study.py
+++ b/assembly_uploader/release_study.py
@@ -1,0 +1,79 @@
+import argparse
+import logging
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from xml.dom import minidom
+
+import requests
+
+from assembly_uploader.submit_study import DROPBOX_DEV, DROPBOX_PROD
+from assembly_uploader.webin_utils import (
+    ensure_webin_credentials_exist,
+    get_webin_credentials,
+)
+
+
+class StudyReleaseError(Exception):
+    pass
+
+
+def release_study(accession: str, is_test: bool = False, xml_path: Path = None):
+    """
+    Immediately publicly release a study, so that it is no longer private/embargoed/held in ENA.
+    :param accession: study accession
+    :param is_test: If true, will use wwwdev ENA Test Webin dropbox
+    :param xml_path: Optional path to use for the submission xml file, otherwise a temp dir will be used.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        xml_path = xml_path or Path(tmp_dir) / Path(accession + ".xml")
+
+        with xml_path.open("wb") as release_file:
+            submission = ET.Element("SUBMISSION")
+            actions = ET.SubElement(submission, "ACTIONS")
+            action_sub = ET.SubElement(actions, "ACTION")
+            release = ET.SubElement(action_sub, "RELEASE")
+            release.set("target", accession)
+            dom = minidom.parseString(ET.tostring(submission, encoding="utf-8"))
+            release_file.write(dom.toprettyxml().encode("utf-8"))
+
+        endpoint = DROPBOX_DEV if is_test else DROPBOX_PROD
+
+        files = {
+            "SUBMISSION": xml_path.open("rb"),
+        }
+
+        release_report = requests.post(
+            endpoint, files=files, auth=get_webin_credentials()
+        )
+        receipt_xml_str = release_report.content.decode("utf-8")
+        if 'success="true"' in receipt_xml_str:
+            logging.info(f"Released study {accession}")
+        else:
+            raise StudyReleaseError(f"Failed to release {accession}. {receipt_xml_str}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Release a private/held study on ENA, e.g. an uploaded assembly study"
+    )
+    parser.add_argument("--study", help="Study ID", required=True)
+    parser.add_argument(
+        "--xml_path", help="Path to use for the release XML submission", required=False
+    )
+    parser.add_argument(
+        "--test",
+        help="Use Webin Dev dropbox instead of prod",
+        required=False,
+        default=False,
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    ensure_webin_credentials_exist()
+
+    release_study(args.study, args.test, Path(args.xml_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ packages = ["assembly_uploader"]
 study_xmls = "assembly_uploader.study_xmls:main"
 submit_study = "assembly_uploader.submit_study:main"
 assembly_manifest = "assembly_uploader.assembly_manifest:main"
+release_study = "assembly_uploader.release_study:main"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/unit/test_release_study.py
+++ b/tests/unit/test_release_study.py
@@ -1,0 +1,44 @@
+import pytest
+import responses
+
+from assembly_uploader.release_study import StudyReleaseError, release_study
+from assembly_uploader.webin_utils import (
+    ENA_WEBIN,
+    ENA_WEBIN_PASSWORD,
+    ensure_webin_credentials_exist,
+)
+
+
+def test_release_study(study_submission_xml_dir, monkeypatch, tmp_path):
+    ena_dropbox = responses.add(
+        responses.POST,
+        "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit",
+        body="""
+        This is a long receipt from the dropbox.
+        success="true"
+        Your study was released.
+        """,
+    )
+
+    with pytest.raises(Exception):
+        ensure_webin_credentials_exist()
+
+    monkeypatch.setenv(ENA_WEBIN, "fake-webin-999")
+    monkeypatch.setenv(ENA_WEBIN_PASSWORD, "fakewebinpw")
+
+    ensure_webin_credentials_exist()
+
+    release_study("SRP272267", is_test=True, xml_path=tmp_path / "test.xml")
+    assert ena_dropbox.call_count == 1
+    assert (tmp_path / "test.xml").is_file()
+    assert '<RELEASE target="SRP272267"/>' in (tmp_path / "test.xml").read_text()
+
+    responses.add(
+        responses.POST,
+        "https://wwwdev.ebi.ac.uk/ena/submit/drop-box/submit",
+        body="""
+        Could not release
+        """,
+    )
+    with pytest.raises(StudyReleaseError):
+        release_study("SRP272267", is_test=True, xml_path=tmp_path / "test.xml")


### PR DESCRIPTION
This PR:
* adds a `release_study` command for publicly releasing private tpa studies. Supported in both CLI mode and lib mode.