### PR TITLE
Solve minor metadata bug for private studies

### DIFF
--- a/assembly_uploader/ena_queries.py
+++ b/assembly_uploader/ena_queries.py
@@ -123,12 +123,21 @@ class EnaQuery:
         response = self.retry_or_handle_request_error(self.get_request, url)
         study = self.get_data_or_handle_error(response)
         study_data = study["report"]
-        reformatted_data = {
-            "study_accession": study_data["secondaryId"],
-            "study_title": study_data["title"],
-            #   remove time and keep date
-            "first_public": study_data["firstPublic"].split("T")[0],
-        }
+        try:
+            reformatted_data = {
+                "study_accession": study_data["secondaryId"],
+                "study_title": study_data["title"],
+                #   remove time and keep date
+                "first_public": study_data["firstPublic"].split("T")[0],
+            }
+        except AttributeError:
+            # if the release date was postponed, firstPublic == None 
+            # fallback on holDate
+            reformatted_data = {
+                "study_accession": study_data["secondaryId"],
+                "study_title": study_data["title"],
+                "first_public": study_data["holdDate"].split("T")[0],
+            }
         logging.info(f"{self.accession} private study returned from ENA")
         return reformatted_data
 

--- a/assembly_uploader/ena_queries.py
+++ b/assembly_uploader/ena_queries.py
@@ -131,8 +131,8 @@ class EnaQuery:
                 "first_public": study_data["firstPublic"].split("T")[0],
             }
         except AttributeError:
-        # if the release date was postponed, firstPublic == None 
-        # fallback on holDate
+            # if the release date was postponed, firstPublic == None
+            # fallback on holDate
             reformatted_data = {
                 "study_accession": study_data["secondaryId"],
                 "study_title": study_data["title"],

--- a/assembly_uploader/ena_queries.py
+++ b/assembly_uploader/ena_queries.py
@@ -132,7 +132,7 @@ class EnaQuery:
             }
         except AttributeError:
             # if the release date was postponed, firstPublic == None
-            # fallback on holDate
+            # fallback on holdDate
             reformatted_data = {
                 "study_accession": study_data["secondaryId"],
                 "study_title": study_data["title"],

--- a/assembly_uploader/ena_queries.py
+++ b/assembly_uploader/ena_queries.py
@@ -127,7 +127,7 @@ class EnaQuery:
             reformatted_data = {
                 "study_accession": study_data["secondaryId"],
                 "study_title": study_data["title"],
-                #   remove time and keep date
+                # remove time and keep date
                 "first_public": study_data["firstPublic"].split("T")[0],
             }
         except AttributeError:

--- a/assembly_uploader/ena_queries.py
+++ b/assembly_uploader/ena_queries.py
@@ -131,8 +131,8 @@ class EnaQuery:
                 "first_public": study_data["firstPublic"].split("T")[0],
             }
         except AttributeError:
-            # if the release date was postponed, firstPublic == None 
-            # fallback on holDate
+        # if the release date was postponed, firstPublic == None 
+        # fallback on holDate
             reformatted_data = {
                 "study_accession": study_data["secondaryId"],
                 "study_title": study_data["title"],


### PR DESCRIPTION
The "firstPublic" field for a study is usually different than None, which is not the case for when the publication date is postponed. In that case, we need to access the "holdDate" field.